### PR TITLE
fix(spring-ai-chat-qwen): 修复 API 密钥配置问题

### DIFF
--- a/spring-ai-chat/spring-ai-chat-qwen/src/main/resources/application.properties
+++ b/spring-ai-chat/spring-ai-chat-qwen/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.port=8085
 spring.profiles.active=qwen
 
 # qwen model
-spring.ai.openai.chat.api-key=${spring.ai.openai.api-key}
+spring.ai.openai.api-key=${spring.ai.openai.api-key}
 spring.ai.openai.chat.base-url=https://dashscope.aliyuncs.com/compatible-mode
 spring.ai.openai.chat.completions-path=/v1/chat/completions
 spring.ai.openai.chat.options.model=qwen-plus


### PR DESCRIPTION
- 将 spring.ai.openai.chat.api-key 更名为 spring.ai.openai.api-key
- 统一 API 密钥配置，解决潜在的配置错误问题