### PR TITLE
feat(spring-ai-observability): 添加可观察性模块

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -1,12 +1,14 @@
 # Spring AI Summary
 
 ![Spring AI Summary](https://img.shields.io/badge/spring--ai--summary-v1.0.0-blue.svg)
+![Visitors](https://visitor-badge.laobi.icu/badge?page_id=java-ai-tech.spring-ai-summary)
 
 <p align="left">
-  <a href="README.md" style="text-decoration:none;"><span style="display:inline-block;border:1px solid #ccc;border-radius:4px;padding:2px 10px;margin-right:10px;">🇨🇳 中文</span></a>
-  <a href="README_EN.md" style="text-decoration:none;"><span style="display:inline-block;border:1px solid #ccc;border-radius:4px;padding:2px 10px;">🇺🇸 English</span></a>
-  <a href="https://github.com/java-ai-tech/spring-ai-summary/wiki" target="_blank"><span style="display:inline-block;border:1px solid #ccc;border-radius:4px;padding:2px 10px;">📖 Wiki</span></a>
+  <a href="README.md" target="_blank"><img src="https://img.shields.io/badge/lang-中文-red?logo=googletranslate" alt="中文" style="vertical-align:middle; margin-right:4px;"/></a>
+  <a href="README_EN.md" target="_blank"><img src="https://img.shields.io/badge/lang-English-blue?logo=googletranslate" alt="English" style="vertical-align:middle; margin-right:4px;"/></a>
+  <a href="https://github.com/java-ai-tech/spring-ai-summary/wiki" target="_blank"><img src="https://img.shields.io/badge/doc-wiki-blue?logo=readthedocs" alt="doc" style="vertical-align:middle; margin-right:4px;"/></a>
 </p>
+
 
 🚀🚀🚀 Spring AI Summary is a collection of sample projects based on native Spring AI, designed to help developers quickly master the core features and usage of the Spring AI framework. With a modular design, each module focuses on a specific functional area, providing clear code examples and detailed documentation to help you get started easily and deeply understand the core concepts of the framework.
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>spring-ai-chat-memory</module>
         <module>spring-ai-tool-calling</module>
         <module>spring-ai-agent</module>
+        <module>spring-ai-observability</module>
     </modules>
 
     <properties>

--- a/spring-ai-chat/spring-ai-chat-qwen/src/main/resources/application.properties
+++ b/spring-ai-chat/spring-ai-chat-qwen/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.port=8085
 spring.profiles.active=qwen
 
 # qwen model
-spring.ai.openai.chat.api-key=${spring.ai.openai.api-key}
+spring.ai.openai.api-key=${spring.ai.openai.api-key}
 spring.ai.openai.chat.base-url=https://dashscope.aliyuncs.com/compatible-mode
 spring.ai.openai.chat.completions-path=/v1/chat/completions
 spring.ai.openai.chat.options.model=qwen-plus

--- a/spring-ai-observability/pom.xml
+++ b/spring-ai-observability/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.glmapper</groupId>
+        <artifactId>spring-ai-summary</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <artifactId>spring-ai-observability</artifactId>
+    <packaging>pom</packaging>
+    <name>spring-ai-observability</name>
+    <modules>
+        <module>spring-ai-observability-metric</module>
+        <module>spring-ai-observability-tracing</module>
+    </modules>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
+        </dependency>
+
+        <!--    redis vector    -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-vector-store-redis</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/spring-ai-observability/spring-ai-observability-metric/README.md
+++ b/spring-ai-observability/spring-ai-observability-metric/README.md
@@ -50,7 +50,7 @@ spring-ai-observability-metric
 ## 🚀 快速启动
 ### 1. 修改配置
 
-在 [application.yml](file:///Users/mrliu/githubWorkspace/spring-ai-summary/spring-ai-mcp/mcp-server-weather/target/classes/application.yml) 中更新以下参数：
+在 [application.yml](src/main/resources) 中更新以下参数：
 
 ```yaml
 spring:

--- a/spring-ai-observability/spring-ai-observability-metric/README.md
+++ b/spring-ai-observability/spring-ai-observability-metric/README.md
@@ -1,0 +1,125 @@
+# Spring AI Observability Metric
+
+该项目是基于 [Spring AI](https://docs.spring.io/spring-ai/) 构建的可观察性追踪示例，集成了 **OpenAI 客户端**（兼容阿里云 DashScope）、**工具调用（Function/Method）** 和 **向量存储（Redis VectorStore）** 功能。
+ 
+
+通过本项目可以快速了解如何在 Spring Boot 应用中实现对 AI 模型调用的监控、追踪和可观测性管理。
+
+
+## 模块结构
+
+```
+spring-ai-observability-metric
+├── src/
+│   ├── main/
+│   │   ├── java/com/glmapper/ai/observability/tracing/
+│   │   │   ├── controller/       # 各类 REST 接口（Chat, Image, Embedding, Tools）
+│   │   │   ├── tools/            # 工具函数（天气查询、时间获取）
+│   │   │   ├── storage/          # Redis VectorStore 存储封装
+│   │   │   └── configs/          # 配置类
+│   │   └── resources/
+│   │       └── application.yml   # 配置文件
+├── pom.xml                       # Maven 项目配置
+└── README.md                     # 当前文档
+```
+
+## 🧩 核心功能
+
+| 模块 | 功能描述 |
+|------|----------|
+| ChatController | 调用 OpenAI 兼容接口进行聊天对话 |
+| ImageController | 调用图像生成 API（如 Stable Diffusion） |
+| EmbeddingController | 使用文本嵌入模型生成向量表示 |
+| ToolCallingController | 支持 Function 和 Method 类型工具调用（天气、当前时间） |
+| VectorStoreController | 使用 Redis 作为向量数据库进行文档存储与搜索 |
+| Zipkin 集成 | 所有请求链路信息上报至 Zipkin，支持全链路追踪 |
+
+---
+
+## 🛠️ 技术栈
+
+- Spring Boot 3.x
+- Spring AI 1.0.x
+- Redis VectorStore
+- OpenAI Client（兼容 DashScope）
+- Micrometer Tracing + Brave
+- Zipkin 分布式追踪
+
+---
+
+## 🚀 快速启动
+### 1. 修改配置
+
+在 [application.yml](file:///Users/mrliu/githubWorkspace/spring-ai-summary/spring-ai-mcp/mcp-server-weather/target/classes/application.yml) 中更新以下参数：
+
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: your-api-key-here
+```
+
+### 2. 启动应用
+
+```bash
+mvn spring-boot:run
+```
+
+或构建后运行：
+
+```bash
+mvn clean package
+java -jar target/spring-ai-observability-tracing-*.jar
+```
+
+---
+
+## 🌐 接口列表
+
+| 接口路径                                  | 描述                     |
+|---------------------------------------|------------------------|
+| /observability/chat?message=xxx       | 发送聊天消息给 AI 模型          |
+| /observability/image                  | 生成一张图片                 |
+| /observability/embedding              | 获取 "hello world" 的文本嵌入 |
+| /observability/embedding/generic      | 使用指定模型获取嵌入             |
+| /observability/tools/function         | 调用 Function 工具（天气）     |
+| /observability/tools/method           | 调用 Method 工具（当前时间）     |
+| /observability/vector/store?text=xxx  | 存储文档到 Redis 向量库        |
+| /observability/vector/search?text=xxx | 在向量库中搜索相似内容            |
+| /observability/vector/delete?id=xxx   | 删除向量库中指定id内容                 |
+
+---
+
+## 📊观测指标查看
+
+项目使用 Micrometer 和 Spring Boot Actuator 来暴露和管理指标数据。可以通过以下步骤查看观测指标：
+
+1. **启动应用**：确保应用已经成功启动。
+
+2. **访问指标端点**：通过浏览器或 HTTP 客户端访问 `/actuator/metrics` 端点。
+
+   ```bash
+   curl http://localhost:8087/actuator/metrics
+   ```
+
+3. **查看具体指标**：可以通过指定指标名称来查看具体的指标详情。
+
+   ```bash
+   curl http://localhost:8087/actuator/metrics/[metricName]
+   ```
+
+   其中 `[metricName]` 是你想查看的具体指标名称。
+
+4. **Prometheus 格式**：如果需要以 Prometheus 格式查看指标，可以访问 `/actuator/prometheus` 端点。
+
+   ```bash
+   curl http://localhost:8087/actuator/prometheus
+   ```
+
+这些指标包括但不限于 JVM 指标、系统指标、HTTP 请求统计等。通过这些指标，可以更好地监控和诊断应用程序的运行状态。
+
+## 📝 注意事项
+
+- 确保已安装并运行 Redis。
+- 如需部署到生产环境，请关闭 debug 日志并调整采样率（`management.tracing.sampling.probability`）。
+- 若更换为其他 OpenAI 兼容平台，请修改对应的 `base-url` 和 `api-key`。

--- a/spring-ai-observability/spring-ai-observability-metric/pom.xml
+++ b/spring-ai-observability/spring-ai-observability-metric/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.glmapper</groupId>
+        <artifactId>spring-ai-observability</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <groupId>com.glmapper.ai.observability.metric</groupId>
+    <artifactId>spring-ai-observability-metric</artifactId>
+
+
+</project>

--- a/spring-ai-observability/spring-ai-observability-metric/request.http
+++ b/spring-ai-observability/spring-ai-observability-metric/request.http
@@ -1,0 +1,26 @@
+### chat
+GET http://localhost:8087/observability/chat
+
+### embedding
+GET http://localhost:8087/observability/embedding
+
+### embedding generic
+GET http://localhost:8087/observability/embedding/generic
+
+### image
+GET http://localhost:8087/observability/image
+
+### tools function
+GET http://localhost:8087/observability/tools/function
+
+### tools method
+GET http://localhost:8087/observability/tools/method
+
+### vector store
+GET http://localhost:8087/observability/vector/store?text=
+
+### vector search
+GET http://localhost:8087/observability/vector/search?text=
+
+### vector delete
+GET http://localhost:8087/observability/vector/delete?id=

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/ObservabilityMetricApplication.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/ObservabilityMetricApplication.java
@@ -1,0 +1,14 @@
+package com.glmapper.ai.observability.metric;
+
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ObservabilityMetricApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ObservabilityMetricApplication.class, args);
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/configs/WeatherToolsConfigs.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/configs/WeatherToolsConfigs.java
@@ -1,0 +1,25 @@
+package com.glmapper.ai.observability.metric.configs;
+
+import com.glmapper.ai.observability.metric.tools.function.WeatherRequest;
+import com.glmapper.ai.observability.metric.tools.function.WeatherResponse;
+import com.glmapper.ai.observability.metric.tools.function.WeatherService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+
+import java.util.function.Function;
+
+
+@Configuration(proxyBeanMethods = false)
+public class WeatherToolsConfigs {
+    public static final String CURRENT_WEATHER_TOOL = "currentWeather";
+
+    WeatherService weatherService = new WeatherService();
+
+    @Bean(CURRENT_WEATHER_TOOL)
+    @Description("Get the weather in location")
+    Function<WeatherRequest, WeatherResponse> currentWeather() {
+        return weatherService;
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ChatController.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ChatController.java
@@ -1,0 +1,31 @@
+package com.glmapper.ai.observability.metric.controller;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/observability/chat")
+public class ChatController {
+
+    private final ChatClient chatClient;
+
+    public ChatController(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
+
+    @GetMapping
+    public String chat(@RequestParam String message) {
+        // 自动记录 spring.ai.chat.client 观测数据
+        return chatClient.prompt()
+                .user(message)
+                .call()
+                .content();
+    }
+
+
+
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/EmbeddingController.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/EmbeddingController.java
@@ -1,0 +1,39 @@
+package com.glmapper.ai.observability.metric.controller;
+
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/observability/embedding")
+public class EmbeddingController {
+
+    private final EmbeddingModel embeddingModel;
+
+    public EmbeddingController(EmbeddingModel embeddingModel) {
+        this.embeddingModel = embeddingModel;
+    }
+
+    @GetMapping
+    public String embedding() {
+        var embeddings = embeddingModel.embed("hello world.");
+        return "embedding vector size:" + embeddings.length;
+    }
+
+    @GetMapping("/generic")
+    public String embeddingGenericOpts() {
+
+        var embeddings = embeddingModel.call(new EmbeddingRequest(
+                List.of("hello world."),
+                OpenAiEmbeddingOptions.builder().model("text-embedding-v4").build())
+        ).getResult().getOutput();
+        return "embedding vector size:" + embeddings.length;
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ImageController.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ImageController.java
@@ -1,0 +1,46 @@
+package com.glmapper.ai.observability.metric.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+
+@RestController
+@RequestMapping("/observability/image")
+public class ImageController {
+
+    private final ImageModel imageModel;
+
+    private static final String DEFAULT_PROMPT = "为人工智能生成一张富有科技感的图片！";
+
+    public ImageController(ImageModel imageModel) {
+        this.imageModel = imageModel;
+    }
+
+    @GetMapping
+    public void image(HttpServletResponse response) {
+
+        ImageResponse imageResponse = imageModel.call(new ImagePrompt(DEFAULT_PROMPT));
+        String imageUrl = imageResponse.getResult().getOutput().getUrl();
+
+        try {
+            URL url = URI.create(imageUrl).toURL();
+            InputStream in = url.openStream();
+
+            response.setHeader("Content-Type", MediaType.IMAGE_PNG_VALUE);
+            response.getOutputStream().write(in.readAllBytes());
+            response.getOutputStream().flush();
+        } catch (IOException e) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ImageController.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ImageController.java
@@ -27,20 +27,10 @@ public class ImageController {
     }
 
     @GetMapping
-    public void image(HttpServletResponse response) {
+    public String image() {
 
         ImageResponse imageResponse = imageModel.call(new ImagePrompt(DEFAULT_PROMPT));
-        String imageUrl = imageResponse.getResult().getOutput().getUrl();
 
-        try {
-            URL url = URI.create(imageUrl).toURL();
-            InputStream in = url.openStream();
-
-            response.setHeader("Content-Type", MediaType.IMAGE_PNG_VALUE);
-            response.getOutputStream().write(in.readAllBytes());
-            response.getOutputStream().flush();
-        } catch (IOException e) {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-        }
+        return imageResponse.getResult().getOutput().getUrl();
     }
 }

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ToolCallingController.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/ToolCallingController.java
@@ -1,0 +1,49 @@
+package com.glmapper.ai.observability.metric.controller;
+
+import com.glmapper.ai.observability.metric.tools.function.WeatherRequest;
+import com.glmapper.ai.observability.metric.tools.function.WeatherService;
+import com.glmapper.ai.observability.metric.tools.methods.DateTimeTools;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/observability/tools")
+public class ToolCallingController {
+
+	public final ChatClient chatClient;
+
+	public ToolCallingController(ChatClient.Builder builder) {
+		this.chatClient = builder.build();
+	}
+
+	@GetMapping("/function")
+	public String functionTools() {
+		ToolCallback toolCallback = FunctionToolCallback
+				.builder("currentWeather", new WeatherService())
+				.description("Get the weather in location")
+				.inputType(WeatherRequest.class)
+				.build();
+
+		return chatClient
+				.prompt("上海的天气怎么样？")
+				.toolCallbacks(toolCallback)
+				.call()
+				.content();
+	}
+
+	// 记录 tools 观测数据
+	@GetMapping("/method")
+	public String methodTools() {
+		return chatClient
+				.prompt("今天是几号？")
+				.tools(new DateTimeTools())
+				.call()
+				.content();
+	}
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/VectorStoreController.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/controller/VectorStoreController.java
@@ -1,0 +1,41 @@
+package com.glmapper.ai.observability.metric.controller;
+
+
+import com.glmapper.ai.observability.metric.storage.VectorStoreStorage;
+import org.springframework.ai.document.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/observability/vector")
+public class VectorStoreController {
+
+    @Autowired()
+    private VectorStoreStorage vectorStoreStorage;
+
+    @GetMapping("/store")
+    public String embedding(@RequestParam String text) {
+        Document document = new Document(text, Map.of("test-data", "true"));
+        List<Document> documents = List.of(document);
+        vectorStoreStorage.store(documents);
+        return document.getId();
+    }
+
+    @GetMapping("/search")
+    public List<Document> search(@RequestParam String text) {
+        return vectorStoreStorage.search(text);
+    }
+
+    @GetMapping("/delete")
+    public void delete(@RequestParam String id) {
+        vectorStoreStorage.delete(Set.of(id));
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/storage/VectorStoreStorage.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/storage/VectorStoreStorage.java
@@ -1,0 +1,39 @@
+package com.glmapper.ai.observability.metric.storage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+
+@Component
+@RequiredArgsConstructor
+public class VectorStoreStorage {
+
+    private final VectorStore vectorStore;
+
+
+    public void delete(Set<String> ids) {
+        vectorStore.delete(new ArrayList<>(ids));
+    }
+
+    public void store(List<Document> documents) {
+        if (documents == null || documents.isEmpty()) {
+            return;
+        }
+        vectorStore.add(documents);
+    }
+
+    public List<Document> search(String query) {
+        return vectorStore.similaritySearch(SearchRequest.builder()
+                .query(query)
+                .topK(5)
+                .similarityThreshold(0.7)
+                .build());
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/Unit.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/Unit.java
@@ -1,0 +1,11 @@
+package com.glmapper.ai.observability.metric.tools.function;
+
+/**
+ * @Classname Unit
+ * @Description TODO
+ * @Date 2025/5/29 17:07
+ * @Created by glmapper
+ */
+public enum Unit {
+    C, F
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/WeatherRequest.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/WeatherRequest.java
@@ -1,0 +1,10 @@
+package com.glmapper.ai.observability.metric.tools.function;
+
+
+/**
+ * @Classname WeatherRequest
+ * @Description WeatherRequest
+ */
+public record WeatherRequest(String location, Unit unit) {
+
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/WeatherResponse.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/WeatherResponse.java
@@ -1,0 +1,10 @@
+package com.glmapper.ai.observability.metric.tools.function;
+
+
+
+/**
+ * @Classname WeatherResponse
+ * @Description WeatherResponse
+ */
+public record WeatherResponse(double temp, Unit unit) {
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/WeatherService.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/function/WeatherService.java
@@ -1,0 +1,15 @@
+package com.glmapper.ai.observability.metric.tools.function;
+
+import java.util.function.Function;
+
+
+/**
+ * @Classname WeatherService
+ * @Description WeatherService
+ */
+public class WeatherService implements Function<WeatherRequest, WeatherResponse> {
+
+    public WeatherResponse apply(WeatherRequest request) {
+        return new WeatherResponse(30.0, Unit.C);
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/methods/DateTimeTools.java
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/java/com/glmapper/ai/observability/metric/tools/methods/DateTimeTools.java
@@ -1,0 +1,24 @@
+package com.glmapper.ai.observability.metric.tools.methods;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+
+
+public class DateTimeTools {
+
+    @Tool(description = "Get the current date and time in the user's timezone")
+    public String getCurrentDateTime() {
+        return LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toString();
+    }
+
+
+    @Tool(description = "Get the current date and time in the user's timezone")
+    public String getFormatDateTime(ToolContext toolContext) {
+        return new SimpleDateFormat(toolContext.getContext().get("format").toString())
+                .format(LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toInstant().toEpochMilli());
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-metric/src/main/resources/application.yml
+++ b/spring-ai-observability/spring-ai-observability-metric/src/main/resources/application.yml
@@ -1,0 +1,75 @@
+spring:
+  application:
+    name: spring-ai-observability
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      username: ${REDIS_USERNAME:}
+      password: ${REDIS_PASSWORD:}
+  ai:
+    openai:
+      api-key: ${spring.ai.openai.api-key}
+      chat:
+        base-url: https://dashscope.aliyuncs.com/compatible-mode
+        options:
+          model: qwen-plus
+      image:
+        api-key: ${spring.ai.openai.api-key}
+        base-url: https://dashscope.aliyuncs.com/api
+        options:
+          model: stable-diffusion-xl
+        images-path: /v1/services/aigc/text2image/image-synthesis
+      embedding:
+        # doc reference: https://bailian.console.aliyun.com/?switchAgent=12095181&productCode=p_efm&switchUserType=3&tab=api#/api/?type=model&url=https%3A%2F%2Fhelp.aliyun.com%2Fdocument_detail%2F2712515.html&renderType=iframe
+        base-url: https://dashscope.aliyuncs.com/compatible-mode/v1
+        embeddings-path: /embeddings
+        options:
+          model: text-embedding-v4
+    vectorstore:
+      redis:
+        initialize-schema: true
+        index-name: glmapper
+        prefix: glmapper_
+      observations:
+        # 记录向量存储查询响应内容
+        log-query-response: true
+
+    chat:
+      client:
+        observations:
+          # 是否记录聊天客户端提示内容
+          log-prompt: true
+      observations:
+        # 记录提示内容
+        log-prompt: true
+        # 记录完成内容
+        log-completion: true
+        # 在观察中包含错误日志
+        include-error-logging: true
+    image:
+      observations:
+        # 记录提示内容
+        log-prompt: true
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+server:
+  port: 8087
+  servlet:
+    encoding:
+      charset: utf-8
+      enabled: true
+      force: true

--- a/spring-ai-observability/spring-ai-observability-tracing/README.md
+++ b/spring-ai-observability/spring-ai-observability-tracing/README.md
@@ -64,7 +64,7 @@ docker-compose up -d
 
 ### 2. 修改配置
 
-在 [application.yml](file:///Users/mrliu/githubWorkspace/spring-ai-summary/spring-ai-mcp/mcp-server-weather/target/classes/application.yml) 中更新以下参数：
+在 [application.yml](src/main/resources) 中更新以下参数：
 
 ```yaml
 spring:

--- a/spring-ai-observability/spring-ai-observability-tracing/README.md
+++ b/spring-ai-observability/spring-ai-observability-tracing/README.md
@@ -1,0 +1,119 @@
+# Spring AI Observability Tracing
+
+该项目是基于 [Spring AI](https://docs.spring.io/spring-ai/) 构建的可观察性追踪示例，集成了 **OpenAI 客户端**（兼容阿里云 DashScope）、**工具调用（Function/Method）**、**向量存储（Redis VectorStore）** 和 **分布式追踪（Zipkin）** 功能。
+
+
+通过本项目可以快速了解如何在 Spring Boot 应用中实现对 AI 模型调用的监控、追踪和可观测性管理。
+
+---
+
+## 📦 项目结构
+
+```
+spring-ai-observability-tracing
+├── src/
+│   ├── main/
+│   │   ├── java/com/glmapper/ai/observability/tracing/
+│   │   │   ├── controller/       # 各类 REST 接口（Chat, Image, Embedding, Tools）
+│   │   │   ├── tools/            # 工具函数（天气查询、时间获取）
+│   │   │   ├── storage/          # Redis VectorStore 存储封装
+│   │   │   └── configs/          # 配置类
+│   │   └── resources/
+│   │       └── application.yml   # 配置文件
+│   └── ...
+├── docker-compose.yaml           # Zipkin 服务定义
+├── pom.xml                       # Maven 项目配置
+└── README.md                     # 当前文档
+```
+
+---
+
+## 🧩 核心功能
+
+| 模块 | 功能描述 |
+|------|----------|
+| ChatController | 调用 OpenAI 兼容接口进行聊天对话 |
+| ImageController | 调用图像生成 API（如 Stable Diffusion） |
+| EmbeddingController | 使用文本嵌入模型生成向量表示 |
+| ToolCallingController | 支持 Function 和 Method 类型工具调用（天气、当前时间） |
+| VectorStoreController | 使用 Redis 作为向量数据库进行文档存储与搜索 |
+| Zipkin 集成 | 所有请求链路信息上报至 Zipkin，支持全链路追踪 |
+
+---
+
+## 🛠️ 技术栈
+
+- Spring Boot 3.x
+- Spring AI 1.0.x
+- Redis VectorStore
+- OpenAI Client（兼容 DashScope）
+- Micrometer Tracing + Brave
+- Zipkin 分布式追踪
+
+---
+
+## 🚀 快速启动
+
+### 1. 启动 Zipkin（使用 Docker）
+
+```bash
+docker-compose up -d
+```
+
+访问：[http://localhost:9411](http://localhost:9411)
+
+### 2. 修改配置
+
+在 [application.yml](file:///Users/mrliu/githubWorkspace/spring-ai-summary/spring-ai-mcp/mcp-server-weather/target/classes/application.yml) 中更新以下参数：
+
+```yaml
+spring:
+  ai:
+    openai:
+      api-key: your-api-key-here
+```
+
+### 3. 启动应用
+
+```bash
+mvn spring-boot:run
+```
+
+或构建后运行：
+
+```bash
+mvn clean package
+java -jar target/spring-ai-observability-tracing-*.jar
+```
+
+---
+
+## 🌐 接口列表
+
+| 接口路径                                  | 描述                     |
+|---------------------------------------|------------------------|
+| /observability/chat?message=xxx       | 发送聊天消息给 AI 模型          |
+| /observability/image                  | 生成一张图片                 |
+| /observability/embedding              | 获取 "hello world" 的文本嵌入 |
+| /observability/embedding/generic      | 使用指定模型获取嵌入             |
+| /observability/tools/function         | 调用 Function 工具（天气）     |
+| /observability/tools/method           | 调用 Method 工具（当前时间）     |
+| /observability/vector/store?text=xxx  | 存储文档到 Redis 向量库        |
+| /observability/vector/search?text=xxx | 在向量库中搜索相似内容            |
+| /observability/vector/delete?id=xxx   | 删除向量库中指定id内容                 |
+
+---
+
+## 📊 监控指标
+
+- Prometheus 指标地址：\`http://localhost:8088/actuator/prometheus\`
+- 健康检查：\`http://localhost:8088/actuator/health\`
+- 所有链路数据会自动上报至 Zipkin
+
+---
+
+## 📝 注意事项
+
+- 确保已安装并运行 Redis。
+- 如需部署到生产环境，请关闭 debug 日志并调整采样率（`management.tracing.sampling.probability`）。
+- 若更换为其他 OpenAI 兼容平台，请修改对应的 `base-url` 和 `api-key`。

--- a/spring-ai-observability/spring-ai-observability-tracing/docker-compose.yaml
+++ b/spring-ai-observability/spring-ai-observability-tracing/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  zipkin:
+    image: 'openzipkin/zipkin:latest'
+    ports:
+      - '9411:9411'

--- a/spring-ai-observability/spring-ai-observability-tracing/pom.xml
+++ b/spring-ai-observability/spring-ai-observability-tracing/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.glmapper</groupId>
+        <artifactId>spring-ai-observability</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <groupId>com.glmapper.ai.observability.tracing</groupId>
+    <artifactId>spring-ai-observability-tracing</artifactId>
+
+    <dependencies>
+        <!--    zipkin追踪    -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter-brave</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-ai-observability/spring-ai-observability-tracing/request.http
+++ b/spring-ai-observability/spring-ai-observability-tracing/request.http
@@ -1,0 +1,26 @@
+### chat
+GET http://localhost:8088/observability/chat
+
+### embedding
+GET http://localhost:8088/observability/embedding
+
+### embedding generic
+GET http://localhost:8088/observability/embedding/generic
+
+### image
+GET http://localhost:8088/observability/image
+
+### tools function
+GET http://localhost:8088/observability/tools/function
+
+### tools method
+GET http://localhost:8088/observability/tools/method
+
+### vector store
+GET http://localhost:8088/observability/vector/store?text=
+
+### vector search
+GET http://localhost:8088/observability/vector/search?text=
+
+### vector delete
+GET http://localhost:8088/observability/vector/delete?id=

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/ObservabilityTracingApplication.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/ObservabilityTracingApplication.java
@@ -1,0 +1,14 @@
+package com.glmapper.ai.observability.tracing;
+
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ObservabilityTracingApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ObservabilityTracingApplication.class, args);
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/configs/WeatherToolsConfigs.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/configs/WeatherToolsConfigs.java
@@ -1,0 +1,25 @@
+package com.glmapper.ai.observability.tracing.configs;
+
+import com.glmapper.ai.observability.tracing.tools.function.WeatherRequest;
+import com.glmapper.ai.observability.tracing.tools.function.WeatherResponse;
+import com.glmapper.ai.observability.tracing.tools.function.WeatherService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+
+import java.util.function.Function;
+
+
+@Configuration(proxyBeanMethods = false)
+public class WeatherToolsConfigs {
+    public static final String CURRENT_WEATHER_TOOL = "currentWeather";
+
+    WeatherService weatherService = new WeatherService();
+
+    @Bean(CURRENT_WEATHER_TOOL)
+    @Description("Get the weather in location")
+    Function<WeatherRequest, WeatherResponse> currentWeather() {
+        return weatherService;
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/ChatController.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/ChatController.java
@@ -1,0 +1,31 @@
+package com.glmapper.ai.observability.tracing.controller;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/observability/chat")
+public class ChatController {
+
+    private final ChatClient chatClient;
+
+    public ChatController(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
+
+    @GetMapping
+    public String chat(@RequestParam String message) {
+        // 自动记录 spring.ai.chat.client 观测数据
+        return chatClient.prompt()
+                .user(message)
+                .call()
+                .content();
+    }
+
+
+
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/EmbeddingController.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/EmbeddingController.java
@@ -1,0 +1,39 @@
+package com.glmapper.ai.observability.tracing.controller;
+
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/observability/embedding")
+public class EmbeddingController {
+
+    private final EmbeddingModel embeddingModel;
+
+    public EmbeddingController(EmbeddingModel embeddingModel) {
+        this.embeddingModel = embeddingModel;
+    }
+
+    @GetMapping
+    public String embedding() {
+        var embeddings = embeddingModel.embed("hello world.");
+        return "embedding vector size:" + embeddings.length;
+    }
+
+    @GetMapping("/generic")
+    public String embeddingGenericOpts() {
+
+        var embeddings = embeddingModel.call(new EmbeddingRequest(
+                List.of("hello world."),
+                OpenAiEmbeddingOptions.builder().model("text-embedding-v4").build())
+        ).getResult().getOutput();
+        return "embedding vector size:" + embeddings.length;
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/ImageController.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/ImageController.java
@@ -1,0 +1,29 @@
+package com.glmapper.ai.observability.tracing.controller;
+
+import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/observability/image")
+public class ImageController {
+
+    private final ImageModel imageModel;
+
+    private static final String DEFAULT_PROMPT = "为人工智能生成一张富有科技感的图片！";
+
+    public ImageController(ImageModel imageModel) {
+        this.imageModel = imageModel;
+    }
+
+    @GetMapping
+    public String image() {
+
+        ImageResponse imageResponse = imageModel.call(new ImagePrompt(DEFAULT_PROMPT));
+
+        return imageResponse.getResult().getOutput().getUrl();
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/ToolCallingController.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/ToolCallingController.java
@@ -1,0 +1,49 @@
+package com.glmapper.ai.observability.tracing.controller;
+
+import com.glmapper.ai.observability.tracing.tools.function.WeatherRequest;
+import com.glmapper.ai.observability.tracing.tools.function.WeatherService;
+import com.glmapper.ai.observability.tracing.tools.methods.DateTimeTools;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/observability/tools")
+public class ToolCallingController {
+
+	public final ChatClient chatClient;
+
+	public ToolCallingController(ChatClient.Builder builder) {
+		this.chatClient = builder.build();
+	}
+
+	@GetMapping("/function")
+	public String functionTools() {
+		ToolCallback toolCallback = FunctionToolCallback
+				.builder("currentWeather", new WeatherService())
+				.description("Get the weather in location")
+				.inputType(WeatherRequest.class)
+				.build();
+
+		return chatClient
+				.prompt("上海的天气怎么样？")
+				.toolCallbacks(toolCallback)
+				.call()
+				.content();
+	}
+
+	// 记录 tools 观测数据
+	@GetMapping("/method")
+	public String methodTools() {
+		return chatClient
+				.prompt("今天是几号？")
+				.tools(new DateTimeTools())
+				.call()
+				.content();
+	}
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/VectorStoreController.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/controller/VectorStoreController.java
@@ -1,0 +1,41 @@
+package com.glmapper.ai.observability.tracing.controller;
+
+
+import com.glmapper.ai.observability.tracing.storage.VectorStoreStorage;
+import org.springframework.ai.document.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/observability/vector")
+public class VectorStoreController {
+
+    @Autowired()
+    private VectorStoreStorage vectorStoreStorage;
+
+    @GetMapping("/store")
+    public String embedding(@RequestParam String text) {
+        Document document = new Document(text, Map.of("test-data", "true"));
+        List<Document> documents = List.of(document);
+        vectorStoreStorage.store(documents);
+        return document.getId();
+    }
+
+    @GetMapping("/search")
+    public List<Document> search(@RequestParam String text) {
+        return vectorStoreStorage.search(text);
+    }
+
+    @GetMapping("/delete")
+    public void delete(@RequestParam String id) {
+        vectorStoreStorage.delete(Set.of(id));
+    }
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/storage/VectorStoreStorage.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/storage/VectorStoreStorage.java
@@ -1,0 +1,39 @@
+package com.glmapper.ai.observability.tracing.storage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+
+@Component
+@RequiredArgsConstructor
+public class VectorStoreStorage {
+
+    private final VectorStore vectorStore;
+
+
+    public void delete(Set<String> ids) {
+        vectorStore.delete(new ArrayList<>(ids));
+    }
+
+    public void store(List<Document> documents) {
+        if (documents == null || documents.isEmpty()) {
+            return;
+        }
+        vectorStore.add(documents);
+    }
+
+    public List<Document> search(String query) {
+        return vectorStore.similaritySearch(SearchRequest.builder()
+                .query(query)
+                .topK(5)
+                .similarityThreshold(0.7)
+                .build());
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/Unit.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/Unit.java
@@ -1,0 +1,11 @@
+package com.glmapper.ai.observability.tracing.tools.function;
+
+/**
+ * @Classname Unit
+ * @Description TODO
+ * @Date 2025/5/29 17:07
+ * @Created by glmapper
+ */
+public enum Unit {
+    C, F
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/WeatherRequest.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/WeatherRequest.java
@@ -1,0 +1,10 @@
+package com.glmapper.ai.observability.tracing.tools.function;
+
+
+/**
+ * @Classname WeatherRequest
+ * @Description WeatherRequest
+ */
+public record WeatherRequest(String location, Unit unit) {
+
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/WeatherResponse.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/WeatherResponse.java
@@ -1,0 +1,10 @@
+package com.glmapper.ai.observability.tracing.tools.function;
+
+
+
+/**
+ * @Classname WeatherResponse
+ * @Description WeatherResponse
+ */
+public record WeatherResponse(double temp, Unit unit) {
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/WeatherService.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/function/WeatherService.java
@@ -1,0 +1,15 @@
+package com.glmapper.ai.observability.tracing.tools.function;
+
+import java.util.function.Function;
+
+
+/**
+ * @Classname WeatherService
+ * @Description WeatherService
+ */
+public class WeatherService implements Function<WeatherRequest, WeatherResponse> {
+
+    public WeatherResponse apply(WeatherRequest request) {
+        return new WeatherResponse(30.0, Unit.C);
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/methods/DateTimeTools.java
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/java/com/glmapper/ai/observability/tracing/tools/methods/DateTimeTools.java
@@ -1,0 +1,24 @@
+package com.glmapper.ai.observability.tracing.tools.methods;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.context.i18n.LocaleContextHolder;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+
+
+public class DateTimeTools {
+
+    @Tool(description = "Get the current date and time in the user's timezone")
+    public String getCurrentDateTime() {
+        return LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toString();
+    }
+
+
+    @Tool(description = "Get the current date and time in the user's timezone")
+    public String getFormatDateTime(ToolContext toolContext) {
+        return new SimpleDateFormat(toolContext.getContext().get("format").toString())
+                .format(LocalDateTime.now().atZone(LocaleContextHolder.getTimeZone().toZoneId()).toInstant().toEpochMilli());
+    }
+}

--- a/spring-ai-observability/spring-ai-observability-tracing/src/main/resources/application.yml
+++ b/spring-ai-observability/spring-ai-observability-tracing/src/main/resources/application.yml
@@ -1,0 +1,82 @@
+spring:
+  application:
+    name: spring-ai-observability
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      username: ${REDIS_USERNAME:}
+      password: ${REDIS_PASSWORD:}
+  ai:
+    openai:
+      api-key: ${spring.ai.openai.api-key}
+      chat:
+        base-url: https://dashscope.aliyuncs.com/compatible-mode
+        options:
+          model: qwen-plus
+      image:
+        api-key: ${spring.ai.openai.api-key}
+        base-url: https://dashscope.aliyuncs.com/api
+        options:
+          model: stable-diffusion-xl
+        images-path: /v1/services/aigc/text2image/image-synthesis
+      embedding:
+        # doc reference: https://bailian.console.aliyun.com/?switchAgent=12095181&productCode=p_efm&switchUserType=3&tab=api#/api/?type=model&url=https%3A%2F%2Fhelp.aliyun.com%2Fdocument_detail%2F2712515.html&renderType=iframe
+        base-url: https://dashscope.aliyuncs.com/compatible-mode/v1
+        embeddings-path: /embeddings
+        options:
+          model: text-embedding-v4
+    vectorstore:
+      redis:
+        initialize-schema: true
+        index-name: glmapper
+        prefix: glmapper_
+      observations:
+        # 记录向量存储查询响应内容
+        log-query-response: true
+
+    chat:
+      client:
+        observations:
+          # 是否记录聊天客户端提示内容
+          log-prompt: true
+      observations:
+        # 记录提示内容
+        log-prompt: true
+        # 记录完成内容
+        log-completion: true
+        # 在观察中包含错误日志
+        include-error-logging: true
+    image:
+      observations:
+        # 记录提示内容
+        log-prompt: true
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  # zipkin 配置
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans
+  tracing:
+    sampling:
+      probability: 1.0
+
+server:
+  port: 8088
+  servlet:
+    encoding:
+      charset: utf-8
+      enabled: true
+      force: true


### PR DESCRIPTION
- 新增 spring-ai-observability 模块，包含 metric 和 tracing 两个子模块
- 实现了对 AI 模型调用的监控、追踪和可观测性管理
- 集成了 OpenAI 客户端、Redis VectorStore 和 Zipkin 分布式追踪
- 提供了聊天、图像生成、文本嵌入等功能的 REST 接口
- 添加了 Prometheus 指标和健康检查支持

#8 